### PR TITLE
chore: Node.js 24 compatibility — update actions and add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24

### DIFF
--- a/.github/workflows/scrape-outages.yml
+++ b/.github/workflows/scrape-outages.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   fetch-external-data:
     runs-on: ubuntu-latest
@@ -16,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout latest commit
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
 


### PR DESCRIPTION
## Summary

This PR prepares the repository for GitHub Actions' upcoming Node.js 24 runtime by:

1. Adding `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` as a top-level workflow environment variable to opt into early Node.js 24 testing
2. Updating deprecated action versions to their latest compatible releases

## Action Version Updates

| Old Version | New Version |
|---|---|
| `actions/checkout@v2` | `v4` |

## Files Modified

- `.github/workflows/scrape-outages.yml`

## Why?

GitHub Actions is transitioning to Node.js 24 as the default runtime. The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable enables early compatibility testing. Older action versions that lack Node.js 24 support have been updated to versions that include it.
