### PR TITLE
fix: replace CC BY 4.0 with proper data disclaimer

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -5,7 +5,7 @@ This repository contains both software (scripts/workflows for scraping data) and
 ## 1. The Software (Code)
 All software code in this repository, including but not limited to `.github/workflows`, is licensed under the MIT License.
 
-Copyright (c) 2023-2026 Richardson Development
+Copyright (c) 2023-2026 Billy Richardson (richardson.dev, richardsondev)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -28,24 +28,12 @@ SOFTWARE.
 ---
 
 ## 2. The Data (`maplistUT.json`, `maplistWY.json`, `maplistID.json`)
-The data hosted in this repository is sourced from Rocky Mountain Power.
+The outage data hosted in this repository is sourced from and remains the intellectual property of Rocky Mountain Power (a division of PacifiCorp). It is reproduced here for informational, educational, and research purposes only.
 
-The data files are made available under the Creative Commons Attribution 4.0 International License (CC BY 4.0).
+This repository and its maintainers make no claim of ownership over the data. The data is provided "as is" without warranty of any kind.
 
-You are free to:
-* Share — copy and redistribute the material in any medium or format
-* Adapt — remix, transform, and build upon the material for any purpose, even commercially.
-
-Under the following terms:
-* Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You must attribute the original source data to Rocky Mountain Power.
-
-For the full text of the CC BY 4.0 license, please visit:
-https://creativecommons.org/licenses/by/4.0/legalcode
-
-### Data Attribution
+### Data Source
 
 The power outage data provided in `maplistUT.json`, `maplistWY.json`, and `maplistID.json` is generated and maintained by Rocky Mountain Power.
 
-When redistributing or building upon this dataset, you must include the following attribution:
-
-"Data sourced from Rocky Mountain Power. Available at: https://www.rockymountainpower.net/outages-safety.html"
+> Source: Rocky Mountain Power Outage Map — https://www.rockymountainpower.net/outages-safety.html

--- a/maplistID.json
+++ b/maplistID.json
@@ -1,19 +1,7 @@
 {
-  "count": 42,
-  "totalState": 6848,
+  "count": 37,
+  "totalState": 4788,
   "outages": [
-    {
-      "icon": "standard",
-      "longitude": -111.803,
-      "latitude": 42.021,
-      "etr": "Before 12:30 AM on 05/14",
-      "outCount": 1,
-      "custOut": 1,
-      "cause": "Investigating",
-      "crewStatus": "Crews Notified",
-      "reported": "04:11 PM on 05/13",
-      "zip": "83237"
-    },
     {
       "icon": "standard",
       "longitude": -112.311,
@@ -28,39 +16,87 @@
     },
     {
       "icon": "standard",
+      "longitude": -111.737,
+      "latitude": 42.242,
+      "etr": "Before 07:30 PM on 05/13",
+      "outCount": 1,
+      "custOut": 6,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "04:44 PM on 05/13",
+      "zip": "83263"
+    },
+    {
+      "icon": "standard",
+      "longitude": -111.504,
+      "latitude": 42.334,
+      "etr": "Before 09:30 PM on 05/13",
+      "outCount": 1,
+      "custOut": 31,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "04:41 PM on 05/13",
+      "zip": "83254"
+    },
+    {
+      "icon": "standard",
+      "longitude": -112.244,
+      "latitude": 42.713,
+      "etr": "Before 07:30 PM on 05/13",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "05:24 PM on 05/13",
+      "zip": "83250"
+    },
+    {
+      "icon": "standard",
       "longitude": -111.981,
       "latitude": 43.512,
       "etr": "Before 10:00 PM on 05/13",
       "outCount": 1,
       "custOut": 46,
       "cause": "Investigating",
-      "crewStatus": "Crews Notified",
+      "crewStatus": "Crews Arrived",
       "reported": "03:54 PM on 05/13",
       "zip": "83401"
     },
     {
       "icon": "standard",
-      "longitude": -111.961,
-      "latitude": 43.513,
-      "etr": "Before 09:30 PM on 05/13",
+      "longitude": -111.904,
+      "latitude": 43.658,
+      "etr": "Before 10:30 PM on 05/13",
       "outCount": 1,
-      "custOut": 1393,
+      "custOut": 1,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
-      "reported": "03:38 PM on 05/13",
-      "zip": "83401"
+      "reported": "05:23 PM on 05/13",
+      "zip": "83442"
     },
     {
       "icon": "standard",
-      "longitude": -112.233,
-      "latitude": 43.633,
-      "etr": "Assessing",
-      "outCount": 4,
-      "custOut": 97,
-      "cause": "Damaged Line",
+      "longitude": -111.924,
+      "latitude": 43.672,
+      "etr": "Before 10:30 PM on 05/13",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
       "crewStatus": "Crews Notified",
-      "reported": "03:17 PM on 05/13",
-      "zip": "83444, 83402"
+      "reported": "05:12 PM on 05/13",
+      "zip": "83442"
+    },
+    {
+      "icon": "standard",
+      "longitude": -111.904,
+      "latitude": 43.672,
+      "etr": "Before 10:30 PM on 05/13",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "05:22 PM on 05/13",
+      "zip": "83442"
     },
     {
       "icon": "standard",
@@ -76,15 +112,15 @@
     },
     {
       "icon": "standard",
-      "longitude": -112.124,
-      "latitude": 43.712,
-      "etr": "Before 12:30 AM on 05/14",
-      "outCount": 2,
-      "custOut": 778,
+      "longitude": -111.904,
+      "latitude": 43.687,
+      "etr": "Before 10:30 PM on 05/13",
+      "outCount": 1,
+      "custOut": 138,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
-      "reported": "03:13 PM on 05/13",
-      "zip": "83434, 83442, 83425, 83431, 83444, 83402"
+      "reported": "04:29 PM on 05/13",
+      "zip": "83442"
     },
     {
       "icon": "standard",
@@ -127,8 +163,8 @@
       "longitude": -112.946,
       "latitude": 43.797,
       "etr": "Before 11:30 PM on 05/13",
-      "outCount": 2,
-      "custOut": 2,
+      "outCount": 1,
+      "custOut": 1,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "03:42 PM on 05/13",
@@ -138,35 +174,23 @@
       "icon": "standard",
       "longitude": -112.356,
       "latitude": 43.806,
-      "etr": "Before 09:30 PM on 05/13",
-      "outCount": 3,
+      "etr": "Assessing",
+      "outCount": 2,
       "custOut": 340,
-      "cause": "Multiple outages in the area",
+      "cause": "Emergency Repair",
       "crewStatus": "Crews Notified",
       "reported": "01:33 PM on 05/13",
       "zip": "83450, 83425"
     },
     {
       "icon": "standard",
-      "longitude": -111.998,
-      "latitude": 43.809,
-      "etr": "Assessing",
-      "outCount": 1,
-      "custOut": 1,
-      "cause": "Investigating",
-      "crewStatus": "Crews Notified",
-      "reported": "04:29 PM on 05/13",
-      "zip": "83434"
-    },
-    {
-      "icon": "standard",
       "longitude": -111.826,
       "latitude": 43.835,
-      "etr": "Before 01:00 AM on 05/14",
+      "etr": "Before 07:00 PM on 05/13",
       "outCount": 1,
       "custOut": 193,
-      "cause": "Investigating",
-      "crewStatus": "Crews Notified",
+      "cause": "Wind",
+      "crewStatus": "Crews Arrived",
       "reported": "03:55 PM on 05/13",
       "zip": "83440"
     },
@@ -181,6 +205,18 @@
       "crewStatus": "Crews Notified",
       "reported": "03:16 PM on 05/13",
       "zip": "83450, 83435"
+    },
+    {
+      "icon": "standard",
+      "longitude": -111.847,
+      "latitude": 43.861,
+      "etr": "Before 10:30 PM on 05/13",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "05:11 PM on 05/13",
+      "zip": "83440"
     },
     {
       "icon": "standard",
@@ -220,18 +256,6 @@
     },
     {
       "icon": "standard",
-      "longitude": -111.707,
-      "latitude": 43.906,
-      "etr": "Before 12:00 AM on 05/14",
-      "outCount": 1,
-      "custOut": 1,
-      "cause": "Investigating",
-      "crewStatus": "Crews Notified",
-      "reported": "04:10 PM on 05/13",
-      "zip": "83445"
-    },
-    {
-      "icon": "standard",
       "longitude": -112.481,
       "latitude": 43.978,
       "etr": "Assessing",
@@ -244,36 +268,24 @@
     },
     {
       "icon": "standard",
-      "longitude": -112.119,
-      "latitude": 43.982,
-      "etr": "Before 12:00 AM on 05/14",
-      "outCount": 1,
-      "custOut": 1,
-      "cause": "Investigating",
-      "crewStatus": "Crews Notified",
-      "reported": "04:11 PM on 05/13",
-      "zip": "83425"
-    },
-    {
-      "icon": "standard",
       "longitude": -111.999,
       "latitude": 43.983,
       "etr": "Before 12:30 AM on 05/14",
       "outCount": 1,
       "custOut": 19,
       "cause": "Wind",
-      "crewStatus": "Crews Arrived",
+      "crewStatus": "Crews Notified",
       "reported": "01:54 PM on 05/13",
       "zip": "83445"
     },
     {
       "icon": "standard",
-      "longitude": -112.24,
-      "latitude": 43.995,
-      "etr": "Before 11:30 PM on 05/13",
+      "longitude": -112.23,
+      "latitude": 43.988,
+      "etr": "Before 12:00 AM on 05/14",
       "outCount": 1,
-      "custOut": 1,
-      "cause": "Investigating",
+      "custOut": 34,
+      "cause": "Wind",
       "crewStatus": "Crews Notified",
       "reported": "03:54 PM on 05/13",
       "zip": "83425"
@@ -312,18 +324,18 @@
       "custOutUnplan": 5
     },
     {
-      "zipCode": "83237",
+      "zipCode": "83244",
+      "outCountPlan": 0,
+      "outCountUnplan": 4,
+      "custOutPlan": 0,
+      "custOutUnplan": 13
+    },
+    {
+      "zipCode": "83250",
       "outCountPlan": 0,
       "outCountUnplan": 1,
       "custOutPlan": 0,
       "custOutUnplan": 1
-    },
-    {
-      "zipCode": "83244",
-      "outCountPlan": 0,
-      "outCountUnplan": 5,
-      "custOutPlan": 0,
-      "custOutUnplan": 14
     },
     {
       "zipCode": "83252",
@@ -333,18 +345,25 @@
       "custOutUnplan": 2711
     },
     {
-      "zipCode": "83401",
+      "zipCode": "83254",
       "outCountPlan": 0,
-      "outCountUnplan": 2,
+      "outCountUnplan": 1,
       "custOutPlan": 0,
-      "custOutUnplan": 1439
+      "custOutUnplan": 31
     },
     {
-      "zipCode": "83402",
+      "zipCode": "83263",
       "outCountPlan": 0,
-      "outCountUnplan": 3,
+      "outCountUnplan": 1,
       "custOutPlan": 0,
-      "custOutUnplan": 54
+      "custOutUnplan": 6
+    },
+    {
+      "zipCode": "83401",
+      "outCountPlan": 0,
+      "outCountUnplan": 1,
+      "custOutPlan": 0,
+      "custOutUnplan": 46
     },
     {
       "zipCode": "83423",
@@ -356,23 +375,9 @@
     {
       "zipCode": "83425",
       "outCountPlan": 0,
-      "outCountUnplan": 4,
+      "outCountUnplan": 2,
       "custOutPlan": 0,
-      "custOutUnplan": 39
-    },
-    {
-      "zipCode": "83431",
-      "outCountPlan": 0,
-      "outCountUnplan": 1,
-      "custOutPlan": 0,
-      "custOutUnplan": 1
-    },
-    {
-      "zipCode": "83434",
-      "outCountPlan": 0,
-      "outCountUnplan": 3,
-      "custOutPlan": 0,
-      "custOutUnplan": 20
+      "custOutUnplan": 60
     },
     {
       "zipCode": "83435",
@@ -384,30 +389,30 @@
     {
       "zipCode": "83440",
       "outCountPlan": 0,
-      "outCountUnplan": 1,
+      "outCountUnplan": 2,
       "custOutPlan": 0,
-      "custOutUnplan": 193
+      "custOutUnplan": 194
     },
     {
       "zipCode": "83442",
       "outCountPlan": 0,
-      "outCountUnplan": 2,
+      "outCountUnplan": 5,
       "custOutPlan": 0,
-      "custOutUnplan": 10
+      "custOutUnplan": 142
     },
     {
       "zipCode": "83444",
       "outCountPlan": 0,
-      "outCountUnplan": 10,
+      "outCountUnplan": 4,
       "custOutPlan": 0,
-      "custOutUnplan": 913
+      "custOutUnplan": 132
     },
     {
       "zipCode": "83445",
       "outCountPlan": 0,
-      "outCountUnplan": 2,
+      "outCountUnplan": 1,
       "custOutPlan": 0,
-      "custOutUnplan": 20
+      "custOutUnplan": 19
     },
     {
       "zipCode": "83448",
@@ -419,7 +424,7 @@
     {
       "zipCode": "83450",
       "outCountPlan": 0,
-      "outCountUnplan": 8,
+      "outCountUnplan": 7,
       "custOutPlan": 0,
       "custOutUnplan": 710
     },
@@ -435,23 +440,30 @@
     {
       "countyName": "Bannock",
       "outCountPlan": 0,
+      "outCountUnplan": 2,
+      "custOutPlan": 0,
+      "custOutUnplan": 6
+    },
+    {
+      "countyName": "Bear Lake",
+      "outCountPlan": 0,
       "outCountUnplan": 1,
       "custOutPlan": 0,
-      "custOutUnplan": 5
+      "custOutUnplan": 31
     },
     {
       "countyName": "Bonneville",
       "outCountPlan": 0,
-      "outCountUnplan": 4,
+      "outCountUnplan": 1,
       "custOutPlan": 0,
-      "custOutUnplan": 1475
+      "custOutUnplan": 46
     },
     {
       "countyName": "Butte",
       "outCountPlan": 0,
-      "outCountUnplan": 4,
+      "outCountUnplan": 3,
       "custOutPlan": 0,
-      "custOutUnplan": 4
+      "custOutUnplan": 3
     },
     {
       "countyName": "Clark",
@@ -465,21 +477,21 @@
       "outCountPlan": 0,
       "outCountUnplan": 1,
       "custOutPlan": 0,
-      "custOutUnplan": 1
+      "custOutUnplan": 6
     },
     {
       "countyName": "Fremont",
       "outCountPlan": 0,
-      "outCountUnplan": 3,
+      "outCountUnplan": 2,
       "custOutPlan": 0,
-      "custOutUnplan": 21
+      "custOutUnplan": 20
     },
     {
       "countyName": "Jefferson",
       "outCountPlan": 0,
-      "outCountUnplan": 24,
+      "outCountUnplan": 21,
       "custOutPlan": 0,
-      "custOutUnplan": 2177
+      "custOutUnplan": 1511
     },
     {
       "countyName": "Lemhi",

--- a/maplistUT.json
+++ b/maplistUT.json
@@ -1,30 +1,18 @@
 {
-  "count": 155,
-  "totalState": 7863,
+  "count": 160,
+  "totalState": 6360,
   "outages": [
     {
       "icon": "standard",
-      "longitude": -113.29,
-      "latitude": 37.216,
+      "longitude": -113.272,
+      "latitude": 37.217,
       "etr": "Before 07:30 PM on 05/13",
       "outCount": 1,
-      "custOut": 1,
+      "custOut": 17,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "04:22 PM on 05/13",
       "zip": "84774"
-    },
-    {
-      "icon": "standard",
-      "longitude": -113.226,
-      "latitude": 37.479,
-      "etr": "Before 09:00 PM on 05/13",
-      "outCount": 2,
-      "custOut": 1422,
-      "cause": "Damaged Line",
-      "crewStatus": "Crews Notified",
-      "reported": "04:04 PM on 05/13",
-      "zip": "84757, 84742, 84720"
     },
     {
       "icon": "standard",
@@ -49,18 +37,6 @@
       "crewStatus": "Crews Arrived",
       "reported": "12:32 PM on 05/13",
       "zip": "84532"
-    },
-    {
-      "icon": "standard",
-      "longitude": -111.86,
-      "latitude": 38.947,
-      "etr": "Before 06:00 PM on 05/13",
-      "outCount": 1,
-      "custOut": 1,
-      "cause": "Investigating",
-      "crewStatus": "Crews Notified",
-      "reported": "03:22 PM on 05/13",
-      "zip": "84654"
     },
     {
       "icon": "standard",
@@ -100,18 +76,6 @@
     },
     {
       "icon": "standard",
-      "longitude": -112.399,
-      "latitude": 40.394,
-      "etr": "Before 06:00 PM on 05/13",
-      "outCount": 2,
-      "custOut": 6,
-      "cause": "Investigating",
-      "crewStatus": "Crews Notified",
-      "reported": "01:46 PM on 05/13",
-      "zip": "84069, 84071"
-    },
-    {
-      "icon": "standard",
       "longitude": -111.955,
       "latitude": 40.483,
       "etr": "Before 03:30 AM on 05/14",
@@ -120,6 +84,18 @@
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "03:03 PM on 05/13",
+      "zip": "84065"
+    },
+    {
+      "icon": "planned",
+      "longitude": -111.917,
+      "latitude": 40.483,
+      "etr": "Before 02:30 AM on 05/14",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Planned Maintenance",
+      "crewStatus": "Crews Arrived",
+      "reported": "05:02 PM on 05/13",
       "zip": "84065"
     },
     {
@@ -160,15 +136,39 @@
     },
     {
       "icon": "standard",
-      "longitude": -111.918,
-      "latitude": 40.556,
-      "etr": "Before 12:30 AM on 05/14",
+      "longitude": -111.823,
+      "latitude": 40.542,
+      "etr": "Before 02:30 AM on 05/14",
       "outCount": 1,
       "custOut": 1,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
+      "reported": "05:26 PM on 05/13",
+      "zip": "84092"
+    },
+    {
+      "icon": "standard",
+      "longitude": -111.918,
+      "latitude": 40.556,
+      "etr": "Before 03:30 AM on 05/14",
+      "outCount": 2,
+      "custOut": 6,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
       "reported": "03:03 PM on 05/13",
       "zip": "84095"
+    },
+    {
+      "icon": "standard",
+      "longitude": -112.393,
+      "latitude": 40.566,
+      "etr": "Before 08:30 PM on 05/13",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "05:06 PM on 05/13",
+      "zip": "84029"
     },
     {
       "icon": "standard",
@@ -258,24 +258,12 @@
       "icon": "standard",
       "longitude": -111.823,
       "latitude": 40.6,
-      "etr": "Before 12:30 AM on 05/14",
+      "etr": "Assessing",
       "outCount": 2,
       "custOut": 132,
-      "cause": "Investigating",
+      "cause": "Multiple outages in the area",
       "crewStatus": "Crews Arrived",
       "reported": "03:09 PM on 05/13",
-      "zip": "84093"
-    },
-    {
-      "icon": "standard",
-      "longitude": -111.804,
-      "latitude": 40.6,
-      "etr": "Before 05:30 PM on 05/13",
-      "outCount": 1,
-      "custOut": 1,
-      "cause": "Damaged Equipment",
-      "crewStatus": "Crews Notified",
-      "reported": "11:18 AM on 05/13",
       "zip": "84093"
     },
     {
@@ -330,24 +318,12 @@
       "icon": "standard",
       "longitude": -111.862,
       "latitude": 40.629,
-      "etr": "Before 12:30 AM on 05/14",
+      "etr": "Before 03:30 AM on 05/14",
       "outCount": 1,
-      "custOut": 1,
+      "custOut": 9,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "03:23 PM on 05/13",
-      "zip": "84121"
-    },
-    {
-      "icon": "standard",
-      "longitude": -111.843,
-      "latitude": 40.629,
-      "etr": "Before 04:30 PM on 05/13",
-      "outCount": 1,
-      "custOut": 1,
-      "cause": "Damaged Equipment",
-      "crewStatus": "Crews Notified",
-      "reported": "11:17 AM on 05/13",
       "zip": "84121"
     },
     {
@@ -378,9 +354,9 @@
       "icon": "standard",
       "longitude": -111.843,
       "latitude": 40.644,
-      "etr": "Before 01:00 AM on 05/14",
+      "etr": "Before 04:00 AM on 05/14",
       "outCount": 1,
-      "custOut": 1,
+      "custOut": 7,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "03:38 PM on 05/13",
@@ -462,13 +438,13 @@
       "icon": "standard",
       "longitude": -111.862,
       "latitude": 40.672,
-      "etr": "Before 12:30 AM on 05/14",
-      "outCount": 2,
-      "custOut": 157,
+      "etr": "Before 02:30 AM on 05/14",
+      "outCount": 3,
+      "custOut": 388,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "03:14 PM on 05/13",
-      "zip": "84124"
+      "zip": "84117, 84124"
     },
     {
       "icon": "standard",
@@ -486,9 +462,9 @@
       "icon": "standard",
       "longitude": -111.805,
       "latitude": 40.673,
-      "etr": "Before 01:00 AM on 05/14",
-      "outCount": 2,
-      "custOut": 2,
+      "etr": "Before 02:00 AM on 05/14",
+      "outCount": 3,
+      "custOut": 3,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "03:30 PM on 05/13",
@@ -508,36 +484,24 @@
     },
     {
       "icon": "standard",
-      "longitude": -111.462,
-      "latitude": 40.675,
-      "etr": "Before 06:00 PM on 05/13",
-      "outCount": 1,
-      "custOut": 1,
-      "cause": "Investigating",
-      "crewStatus": "Crews Arrived",
-      "reported": "01:32 PM on 05/13",
-      "zip": "84060"
-    },
-    {
-      "icon": "standard",
       "longitude": -111.862,
       "latitude": 40.687,
       "etr": "Before 03:30 AM on 05/14",
-      "outCount": 5,
-      "custOut": 38,
+      "outCount": 3,
+      "custOut": 9,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
-      "reported": "03:16 PM on 05/13",
+      "reported": "03:22 PM on 05/13",
       "zip": "84106, 84124"
     },
     {
       "icon": "standard",
       "longitude": -111.843,
       "latitude": 40.687,
-      "etr": "Before 01:30 AM on 05/14",
-      "outCount": 5,
-      "custOut": 14,
-      "cause": "Investigating",
+      "etr": "Before 01:00 AM on 05/14",
+      "outCount": 4,
+      "custOut": 13,
+      "cause": "Multiple outages in the area",
       "crewStatus": "Crews Notified",
       "reported": "01:16 PM on 05/13",
       "zip": "84106, 84124"
@@ -549,7 +513,7 @@
       "etr": "Before 03:30 AM on 05/14",
       "outCount": 3,
       "custOut": 175,
-      "cause": "Investigating",
+      "cause": "Multiple outages in the area",
       "crewStatus": "Crews Notified",
       "reported": "01:39 PM on 05/13",
       "zip": "84124, 84109"
@@ -560,7 +524,7 @@
       "latitude": 40.687,
       "etr": "Before 03:30 AM on 05/14",
       "outCount": 5,
-      "custOut": 118,
+      "custOut": 127,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "03:24 PM on 05/13",
@@ -642,13 +606,25 @@
       "icon": "standard",
       "longitude": -111.844,
       "latitude": 40.716,
-      "etr": "Before 01:30 AM on 05/14",
+      "etr": "Before 04:30 AM on 05/14",
       "outCount": 2,
-      "custOut": 2,
+      "custOut": 17,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "03:40 PM on 05/13",
       "zip": "84106"
+    },
+    {
+      "icon": "standard",
+      "longitude": -111.825,
+      "latitude": 40.716,
+      "etr": "Before 02:00 AM on 05/14",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "04:33 PM on 05/13",
+      "zip": "84109"
     },
     {
       "icon": "standard",
@@ -703,8 +679,8 @@
       "longitude": -111.844,
       "latitude": 40.731,
       "etr": "Before 04:30 AM on 05/14",
-      "outCount": 4,
-      "custOut": 99,
+      "outCount": 5,
+      "custOut": 100,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "03:18 PM on 05/13",
@@ -714,12 +690,12 @@
       "icon": "standard",
       "longitude": -111.825,
       "latitude": 40.731,
-      "etr": "Before 01:30 AM on 05/14",
-      "outCount": 3,
-      "custOut": 3,
+      "etr": "Before 03:30 AM on 05/14",
+      "outCount": 4,
+      "custOut": 73,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
-      "reported": "03:23 PM on 05/13",
+      "reported": "03:18 PM on 05/13",
       "zip": "84108"
     },
     {
@@ -739,8 +715,8 @@
       "longitude": -111.882,
       "latitude": 40.745,
       "etr": "Before 04:00 AM on 05/14",
-      "outCount": 6,
-      "custOut": 887,
+      "outCount": 5,
+      "custOut": 886,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "03:21 PM on 05/13",
@@ -752,11 +728,35 @@
       "latitude": 40.745,
       "etr": "Before 01:00 AM on 05/14",
       "outCount": 2,
-      "custOut": 2343,
+      "custOut": 2285,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "03:16 PM on 05/13",
       "zip": "84106, 84108, 84109"
+    },
+    {
+      "icon": "standard",
+      "longitude": -111.596,
+      "latitude": 40.747,
+      "etr": "Before 05:00 AM on 05/14",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "04:41 PM on 05/13",
+      "zip": "84098"
+    },
+    {
+      "icon": "standard",
+      "longitude": -111.501,
+      "latitude": 40.747,
+      "etr": "Before 05:30 AM on 05/14",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "05:08 PM on 05/13",
+      "zip": "84098"
     },
     {
       "icon": "standard",
@@ -775,8 +775,8 @@
       "longitude": -111.882,
       "latitude": 40.759,
       "etr": "Before 04:00 AM on 05/14",
-      "outCount": 2,
-      "custOut": 60,
+      "outCount": 3,
+      "custOut": 61,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "03:14 PM on 05/13",
@@ -786,25 +786,13 @@
       "icon": "standard",
       "longitude": -111.863,
       "latitude": 40.759,
-      "etr": "Assessing",
-      "outCount": 3,
-      "custOut": 65,
+      "etr": "Before 02:30 AM on 05/14",
+      "outCount": 5,
+      "custOut": 67,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "03:25 PM on 05/13",
       "zip": "84102"
-    },
-    {
-      "icon": "standard",
-      "longitude": -111.94,
-      "latitude": 40.773,
-      "etr": "Before 04:00 AM on 05/14",
-      "outCount": 1,
-      "custOut": 1,
-      "cause": "Investigating",
-      "crewStatus": "Crews Arrived",
-      "reported": "03:45 PM on 05/13",
-      "zip": "84116"
     },
     {
       "icon": "standard",
@@ -820,27 +808,15 @@
     },
     {
       "icon": "standard",
-      "longitude": -111.902,
-      "latitude": 40.774,
-      "etr": "Before 11:00 PM on 05/13",
-      "outCount": 1,
-      "custOut": 1,
-      "cause": "Investigating",
-      "crewStatus": "Crews Arrived",
-      "reported": "01:46 PM on 05/13",
-      "zip": "84116"
-    },
-    {
-      "icon": "standard",
       "longitude": -111.883,
       "latitude": 40.774,
-      "etr": "Before 10:00 PM on 05/13",
-      "outCount": 1,
-      "custOut": 1,
+      "etr": "Before 05:00 AM on 05/14",
+      "outCount": 2,
+      "custOut": 22,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "12:55 PM on 05/13",
-      "zip": "84111"
+      "zip": "84103, 84111"
     },
     {
       "icon": "standard",
@@ -858,7 +834,7 @@
       "icon": "standard",
       "longitude": -111.177,
       "latitude": 40.777,
-      "etr": "Before 02:00 AM on 05/14",
+      "etr": "Before 07:00 AM on 05/14",
       "outCount": 1,
       "custOut": 994,
       "cause": "Investigating",
@@ -868,9 +844,33 @@
     },
     {
       "icon": "standard",
+      "longitude": -111.94,
+      "latitude": 40.788,
+      "etr": "Before 02:00 AM on 05/14",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "04:32 PM on 05/13",
+      "zip": "84116"
+    },
+    {
+      "icon": "standard",
+      "longitude": -111.902,
+      "latitude": 40.788,
+      "etr": "Before 02:30 AM on 05/14",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "05:11 PM on 05/13",
+      "zip": "84103"
+    },
+    {
+      "icon": "standard",
       "longitude": -111.387,
       "latitude": 40.834,
-      "etr": "Before 12:30 AM on 05/14",
+      "etr": "Before 04:30 AM on 05/14",
       "outCount": 1,
       "custOut": 1,
       "cause": "Investigating",
@@ -904,6 +904,18 @@
     },
     {
       "icon": "standard",
+      "longitude": -111.885,
+      "latitude": 40.919,
+      "etr": "Before 02:00 AM on 05/14",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "04:59 PM on 05/13",
+      "zip": "84014"
+    },
+    {
+      "icon": "standard",
       "longitude": -112.137,
       "latitude": 41.163,
       "etr": "Before 01:30 AM on 05/14",
@@ -913,30 +925,6 @@
       "crewStatus": "Crews Notified",
       "reported": "04:10 PM on 05/13",
       "zip": "84315"
-    },
-    {
-      "icon": "standard",
-      "longitude": -112.041,
-      "latitude": 41.164,
-      "etr": "Before 01:30 AM on 05/14",
-      "outCount": 1,
-      "custOut": 1,
-      "cause": "Investigating",
-      "crewStatus": "Crews Notified",
-      "reported": "04:18 PM on 05/13",
-      "zip": "84067"
-    },
-    {
-      "icon": "standard",
-      "longitude": -112.003,
-      "latitude": 41.193,
-      "etr": "Before 01:30 AM on 05/14",
-      "outCount": 1,
-      "custOut": 1,
-      "cause": "Investigating",
-      "crewStatus": "Crews Notified",
-      "reported": "04:12 PM on 05/13",
-      "zip": "84405"
     },
     {
       "icon": "standard",
@@ -952,6 +940,42 @@
     },
     {
       "icon": "standard",
+      "longitude": -111.965,
+      "latitude": 41.208,
+      "etr": "Before 11:00 PM on 05/13",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "04:52 PM on 05/13",
+      "zip": "84403"
+    },
+    {
+      "icon": "standard",
+      "longitude": -111.946,
+      "latitude": 41.208,
+      "etr": "Before 11:30 PM on 05/13",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "05:18 PM on 05/13",
+      "zip": "84403"
+    },
+    {
+      "icon": "standard",
+      "longitude": -112.004,
+      "latitude": 41.222,
+      "etr": "Before 08:00 AM on 05/14",
+      "outCount": 2,
+      "custOut": 11,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "04:34 PM on 05/13",
+      "zip": "84401"
+    },
+    {
+      "icon": "standard",
       "longitude": -112.186,
       "latitude": 41.226,
       "etr": "Before 07:00 AM on 05/14",
@@ -960,18 +984,6 @@
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "03:50 PM on 05/13",
-      "zip": "84404"
-    },
-    {
-      "icon": "standard",
-      "longitude": -112.14,
-      "latitude": 41.293,
-      "etr": "Assessing",
-      "outCount": 2,
-      "custOut": 2,
-      "cause": "Investigating",
-      "crewStatus": "Crews Notified",
-      "reported": "03:49 PM on 05/13",
       "zip": "84404"
     },
     {
@@ -985,18 +997,6 @@
       "crewStatus": "Crews Notified",
       "reported": "02:36 PM on 05/13",
       "zip": "84414"
-    },
-    {
-      "icon": "standard",
-      "longitude": -112.045,
-      "latitude": 41.367,
-      "etr": "Before 09:30 PM on 05/13",
-      "outCount": 1,
-      "custOut": 1,
-      "cause": "Investigating",
-      "crewStatus": "Crews Arrived",
-      "reported": "03:27 PM on 05/13",
-      "zip": "84340"
     },
     {
       "icon": "standard",
@@ -1024,6 +1024,18 @@
     },
     {
       "icon": "standard",
+      "longitude": -112.088,
+      "latitude": 41.642,
+      "etr": "Before 12:00 AM on 05/14",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "04:59 PM on 05/13",
+      "zip": "84314"
+    },
+    {
+      "icon": "standard",
       "longitude": -112.068,
       "latitude": 41.642,
       "etr": "Before 01:00 AM on 05/14",
@@ -1036,39 +1048,15 @@
     },
     {
       "icon": "standard",
-      "longitude": -112.185,
-      "latitude": 41.67,
-      "etr": "Before 11:30 PM on 05/13",
+      "longitude": -111.837,
+      "latitude": 41.673,
+      "etr": "Before 01:00 AM on 05/14",
       "outCount": 1,
       "custOut": 1,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
-      "reported": "04:22 PM on 05/13",
-      "zip": "84337"
-    },
-    {
-      "icon": "standard",
-      "longitude": -111.972,
-      "latitude": 41.672,
-      "etr": "Assessing",
-      "outCount": 1,
-      "custOut": 1,
-      "cause": "Investigating",
-      "crewStatus": "Crews Notified",
-      "reported": "04:05 PM on 05/13",
-      "zip": "84339"
-    },
-    {
-      "icon": "standard",
-      "longitude": -111.953,
-      "latitude": 41.672,
-      "etr": "Assessing",
-      "outCount": 2,
-      "custOut": 2,
-      "cause": "Investigating",
-      "crewStatus": "Crews Notified",
-      "reported": "03:53 PM on 05/13",
-      "zip": "84339"
+      "reported": "04:37 PM on 05/13",
+      "zip": "84321"
     },
     {
       "icon": "standard",
@@ -1096,23 +1084,11 @@
     },
     {
       "icon": "standard",
-      "longitude": -111.972,
-      "latitude": 41.686,
-      "etr": "Assessing",
-      "outCount": 1,
-      "custOut": 1,
-      "cause": "Investigating",
-      "crewStatus": "Crews Notified",
-      "reported": "04:02 PM on 05/13",
-      "zip": "84325"
-    },
-    {
-      "icon": "standard",
       "longitude": -111.818,
       "latitude": 41.687,
       "etr": "Before 12:30 AM on 05/14",
       "outCount": 1,
-      "custOut": 1,
+      "custOut": 4,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "04:15 PM on 05/13",
@@ -1120,39 +1096,15 @@
     },
     {
       "icon": "standard",
-      "longitude": -111.973,
-      "latitude": 41.701,
-      "etr": "Before 12:30 AM on 05/14",
-      "outCount": 2,
-      "custOut": 44,
-      "cause": "Investigating",
-      "crewStatus": "Crews Notified",
-      "reported": "03:49 PM on 05/13",
-      "zip": "84325"
-    },
-    {
-      "icon": "standard",
-      "longitude": -111.973,
-      "latitude": 41.715,
-      "etr": "Assessing",
-      "outCount": 2,
-      "custOut": 348,
-      "cause": "Investigating",
-      "crewStatus": "Crews Notified",
-      "reported": "03:49 PM on 05/13",
-      "zip": "84325, 84306"
-    },
-    {
-      "icon": "standard",
-      "longitude": -111.973,
-      "latitude": 41.73,
+      "longitude": -111.818,
+      "latitude": 41.702,
       "etr": "Before 11:30 PM on 05/13",
       "outCount": 1,
       "custOut": 1,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
-      "reported": "04:28 PM on 05/13",
-      "zip": "84325"
+      "reported": "04:40 PM on 05/13",
+      "zip": "84332"
     },
     {
       "icon": "standard",
@@ -1168,11 +1120,35 @@
     },
     {
       "icon": "standard",
-      "longitude": -111.819,
-      "latitude": 41.803,
-      "etr": "Before 12:30 AM on 05/14",
+      "longitude": -111.912,
+      "latitude": 41.788,
+      "etr": "Before 12:00 AM on 05/14",
       "outCount": 1,
       "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "04:56 PM on 05/13",
+      "zip": "84335"
+    },
+    {
+      "icon": "standard",
+      "longitude": -111.896,
+      "latitude": 41.788,
+      "etr": "Before 02:00 AM on 05/14",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "05:28 PM on 05/13",
+      "zip": "84335"
+    },
+    {
+      "icon": "standard",
+      "longitude": -111.819,
+      "latitude": 41.803,
+      "etr": "Before 02:00 AM on 05/14",
+      "outCount": 3,
+      "custOut": 3,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "04:06 PM on 05/13",
@@ -1218,13 +1194,13 @@
       "icon": "standard",
       "longitude": -112.199,
       "latitude": 41.894,
-      "etr": "Before 11:00 PM on 05/13",
-      "outCount": 1,
-      "custOut": 1,
+      "etr": "Before 01:30 AM on 05/14",
+      "outCount": 2,
+      "custOut": 2,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
       "reported": "03:55 PM on 05/13",
-      "zip": "84312"
+      "zip": "84330, 84312"
     },
     {
       "icon": "standard",
@@ -1240,18 +1216,61 @@
     },
     {
       "icon": "standard",
-      "longitude": -111.899,
-      "latitude": 41.977,
-      "etr": "Before 12:30 AM on 05/14",
-      "outCount": 1,
-      "custOut": 425,
+      "longitude": -111.937,
+      "latitude": 41.918,
+      "etr": "Before 01:00 AM on 05/14",
+      "outCount": 2,
+      "custOut": 2,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
+      "reported": "04:33 PM on 05/13",
+      "zip": "84338"
+    },
+    {
+      "icon": "standard",
+      "longitude": -111.898,
+      "latitude": 41.933,
+      "etr": "Before 01:00 AM on 05/14",
+      "outCount": 1,
+      "custOut": 1,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "04:34 PM on 05/13",
+      "zip": "84320"
+    },
+    {
+      "icon": "standard",
+      "longitude": -111.84,
+      "latitude": 41.948,
+      "etr": "Before 01:30 AM on 05/14",
+      "outCount": 1,
+      "custOut": 2,
+      "cause": "Investigating",
+      "crewStatus": "Crews Notified",
+      "reported": "04:24 PM on 05/13",
+      "zip": "84320"
+    },
+    {
+      "icon": "standard",
+      "longitude": -111.899,
+      "latitude": 41.977,
+      "etr": "Assessing",
+      "outCount": 1,
+      "custOut": 424,
+      "cause": "Investigating",
+      "crewStatus": "Crews Arrived",
       "reported": "03:59 PM on 05/13",
       "zip": "84320, 84333"
     }
   ],
   "zips": [
+    {
+      "zipCode": "84014",
+      "outCountPlan": 0,
+      "outCountUnplan": 1,
+      "custOutPlan": 0,
+      "custOutUnplan": 1
+    },
     {
       "zipCode": "84017",
       "outCountPlan": 0,
@@ -1262,9 +1281,9 @@
     {
       "zipCode": "84029",
       "outCountPlan": 0,
-      "outCountUnplan": 2,
+      "outCountUnplan": 3,
       "custOutPlan": 0,
-      "custOutUnplan": 8
+      "custOutUnplan": 9
     },
     {
       "zipCode": "84036",
@@ -1295,42 +1314,14 @@
       "custOutUnplan": 1
     },
     {
-      "zipCode": "84060",
-      "outCountPlan": 0,
-      "outCountUnplan": 1,
-      "custOutPlan": 0,
-      "custOutUnplan": 1
-    },
-    {
       "zipCode": "84065",
-      "outCountPlan": 0,
+      "outCountPlan": 1,
       "outCountUnplan": 2,
-      "custOutPlan": 0,
+      "custOutPlan": 1,
       "custOutUnplan": 3
     },
     {
-      "zipCode": "84067",
-      "outCountPlan": 0,
-      "outCountUnplan": 1,
-      "custOutPlan": 0,
-      "custOutUnplan": 1
-    },
-    {
-      "zipCode": "84069",
-      "outCountPlan": 0,
-      "outCountUnplan": 1,
-      "custOutPlan": 0,
-      "custOutUnplan": 5
-    },
-    {
       "zipCode": "84070",
-      "outCountPlan": 0,
-      "outCountUnplan": 1,
-      "custOutPlan": 0,
-      "custOutUnplan": 1
-    },
-    {
-      "zipCode": "84071",
       "outCountPlan": 0,
       "outCountUnplan": 1,
       "custOutPlan": 0,
@@ -1360,23 +1351,23 @@
     {
       "zipCode": "84092",
       "outCountPlan": 0,
-      "outCountUnplan": 2,
+      "outCountUnplan": 3,
       "custOutPlan": 0,
-      "custOutUnplan": 11
+      "custOutUnplan": 12
     },
     {
       "zipCode": "84093",
       "outCountPlan": 0,
-      "outCountUnplan": 5,
+      "outCountUnplan": 4,
       "custOutPlan": 0,
-      "custOutUnplan": 157
+      "custOutUnplan": 156
     },
     {
       "zipCode": "84095",
       "outCountPlan": 0,
-      "outCountUnplan": 1,
+      "outCountUnplan": 2,
       "custOutPlan": 0,
-      "custOutUnplan": 1
+      "custOutUnplan": 6
     },
     {
       "zipCode": "84096",
@@ -1384,6 +1375,13 @@
       "outCountUnplan": 2,
       "custOutPlan": 0,
       "custOutUnplan": 93
+    },
+    {
+      "zipCode": "84098",
+      "outCountPlan": 0,
+      "outCountUnplan": 2,
+      "custOutPlan": 0,
+      "custOutUnplan": 2
     },
     {
       "zipCode": "84101",
@@ -1395,16 +1393,16 @@
     {
       "zipCode": "84102",
       "outCountPlan": 0,
-      "outCountUnplan": 4,
+      "outCountUnplan": 6,
       "custOutPlan": 0,
-      "custOutUnplan": 66
+      "custOutUnplan": 68
     },
     {
       "zipCode": "84103",
       "outCountPlan": 0,
-      "outCountUnplan": 1,
+      "outCountUnplan": 3,
       "custOutPlan": 0,
-      "custOutUnplan": 1
+      "custOutUnplan": 23
     },
     {
       "zipCode": "84104",
@@ -1416,16 +1414,16 @@
     {
       "zipCode": "84105",
       "outCountPlan": 0,
-      "outCountUnplan": 6,
+      "outCountUnplan": 7,
       "custOutPlan": 0,
-      "custOutUnplan": 119
+      "custOutUnplan": 120
     },
     {
       "zipCode": "84106",
       "outCountPlan": 0,
       "outCountUnplan": 10,
       "custOutPlan": 0,
-      "custOutUnplan": 227
+      "custOutUnplan": 242
     },
     {
       "zipCode": "84107",
@@ -1437,44 +1435,44 @@
     {
       "zipCode": "84108",
       "outCountPlan": 0,
-      "outCountUnplan": 5,
+      "outCountUnplan": 6,
       "custOutPlan": 0,
-      "custOutUnplan": 1485
+      "custOutUnplan": 1497
     },
     {
       "zipCode": "84109",
       "outCountPlan": 0,
-      "outCountUnplan": 9,
+      "outCountUnplan": 10,
       "custOutPlan": 0,
-      "custOutUnplan": 934
+      "custOutUnplan": 944
     },
     {
       "zipCode": "84111",
       "outCountPlan": 0,
-      "outCountUnplan": 6,
+      "outCountUnplan": 7,
       "custOutPlan": 0,
-      "custOutUnplan": 340
+      "custOutUnplan": 341
     },
     {
       "zipCode": "84115",
       "outCountPlan": 0,
-      "outCountUnplan": 8,
+      "outCountUnplan": 7,
       "custOutPlan": 0,
-      "custOutUnplan": 612
+      "custOutUnplan": 611
     },
     {
       "zipCode": "84116",
       "outCountPlan": 0,
-      "outCountUnplan": 3,
+      "outCountUnplan": 2,
       "custOutPlan": 0,
-      "custOutUnplan": 3
+      "custOutUnplan": 2
     },
     {
       "zipCode": "84117",
       "outCountPlan": 0,
-      "outCountUnplan": 5,
+      "outCountUnplan": 7,
       "custOutPlan": 0,
-      "custOutUnplan": 5
+      "custOutUnplan": 7
     },
     {
       "zipCode": "84118",
@@ -1493,9 +1491,9 @@
     {
       "zipCode": "84121",
       "outCountPlan": 0,
-      "outCountUnplan": 6,
+      "outCountUnplan": 5,
       "custOutPlan": 0,
-      "custOutUnplan": 91
+      "custOutUnplan": 104
     },
     {
       "zipCode": "84123",
@@ -1507,9 +1505,9 @@
     {
       "zipCode": "84124",
       "outCountPlan": 0,
-      "outCountUnplan": 12,
+      "outCountUnplan": 9,
       "custOutPlan": 0,
-      "custOutUnplan": 226
+      "custOutUnplan": 426
     },
     {
       "zipCode": "84129",
@@ -1526,13 +1524,6 @@
       "custOutUnplan": 1
     },
     {
-      "zipCode": "84306",
-      "outCountPlan": 0,
-      "outCountUnplan": 1,
-      "custOutPlan": 0,
-      "custOutUnplan": 2
-    },
-    {
       "zipCode": "84312",
       "outCountPlan": 0,
       "outCountUnplan": 2,
@@ -1542,9 +1533,9 @@
     {
       "zipCode": "84314",
       "outCountPlan": 0,
-      "outCountUnplan": 1,
+      "outCountUnplan": 2,
       "custOutPlan": 0,
-      "custOutUnplan": 1
+      "custOutUnplan": 2
     },
     {
       "zipCode": "84315",
@@ -1556,30 +1547,30 @@
     {
       "zipCode": "84318",
       "outCountPlan": 0,
-      "outCountUnplan": 1,
+      "outCountUnplan": 3,
       "custOutPlan": 0,
-      "custOutUnplan": 1
+      "custOutUnplan": 3
     },
     {
       "zipCode": "84320",
       "outCountPlan": 0,
-      "outCountUnplan": 1,
+      "outCountUnplan": 3,
       "custOutPlan": 0,
-      "custOutUnplan": 413
+      "custOutUnplan": 415
     },
     {
-      "zipCode": "84325",
+      "zipCode": "84321",
       "outCountPlan": 0,
-      "outCountUnplan": 6,
+      "outCountUnplan": 1,
       "custOutPlan": 0,
-      "custOutUnplan": 392
+      "custOutUnplan": 1
     },
     {
       "zipCode": "84326",
       "outCountPlan": 0,
       "outCountUnplan": 1,
       "custOutPlan": 0,
-      "custOutUnplan": 1
+      "custOutUnplan": 4
     },
     {
       "zipCode": "84328",
@@ -1589,7 +1580,21 @@
       "custOutUnplan": 1
     },
     {
+      "zipCode": "84330",
+      "outCountPlan": 0,
+      "outCountUnplan": 1,
+      "custOutPlan": 0,
+      "custOutUnplan": 1
+    },
+    {
       "zipCode": "84331",
+      "outCountPlan": 0,
+      "outCountUnplan": 1,
+      "custOutPlan": 0,
+      "custOutUnplan": 1
+    },
+    {
+      "zipCode": "84332",
       "outCountPlan": 0,
       "outCountUnplan": 1,
       "custOutPlan": 0,
@@ -1605,51 +1610,51 @@
     {
       "zipCode": "84335",
       "outCountPlan": 0,
-      "outCountUnplan": 2,
+      "outCountUnplan": 4,
       "custOutPlan": 0,
-      "custOutUnplan": 2
+      "custOutUnplan": 4
     },
     {
       "zipCode": "84337",
       "outCountPlan": 0,
-      "outCountUnplan": 3,
+      "outCountUnplan": 2,
       "custOutPlan": 0,
-      "custOutUnplan": 3
+      "custOutUnplan": 2
     },
     {
       "zipCode": "84338",
       "outCountPlan": 0,
-      "outCountUnplan": 1,
-      "custOutPlan": 0,
-      "custOutUnplan": 1
-    },
-    {
-      "zipCode": "84339",
-      "outCountPlan": 0,
       "outCountUnplan": 3,
       "custOutPlan": 0,
       "custOutUnplan": 3
     },
     {
-      "zipCode": "84340",
+      "zipCode": "84401",
       "outCountPlan": 0,
-      "outCountUnplan": 1,
+      "outCountUnplan": 2,
       "custOutPlan": 0,
-      "custOutUnplan": 1
+      "custOutUnplan": 11
     },
     {
-      "zipCode": "84404",
-      "outCountPlan": 0,
-      "outCountUnplan": 3,
-      "custOutPlan": 0,
-      "custOutUnplan": 3
-    },
-    {
-      "zipCode": "84405",
+      "zipCode": "84403",
       "outCountPlan": 0,
       "outCountUnplan": 2,
       "custOutPlan": 0,
       "custOutUnplan": 2
+    },
+    {
+      "zipCode": "84404",
+      "outCountPlan": 0,
+      "outCountUnplan": 1,
+      "custOutPlan": 0,
+      "custOutUnplan": 1
+    },
+    {
+      "zipCode": "84405",
+      "outCountPlan": 0,
+      "outCountUnplan": 1,
+      "custOutPlan": 0,
+      "custOutUnplan": 1
     },
     {
       "zipCode": "84414",
@@ -1694,62 +1699,41 @@
       "custOutUnplan": 2
     },
     {
-      "zipCode": "84654",
+      "zipCode": "84720",
       "outCountPlan": 0,
       "outCountUnplan": 1,
       "custOutPlan": 0,
       "custOutUnplan": 1
-    },
-    {
-      "zipCode": "84720",
-      "outCountPlan": 0,
-      "outCountUnplan": 2,
-      "custOutPlan": 0,
-      "custOutUnplan": 170
-    },
-    {
-      "zipCode": "84742",
-      "outCountPlan": 0,
-      "outCountUnplan": 1,
-      "custOutPlan": 0,
-      "custOutUnplan": 284
-    },
-    {
-      "zipCode": "84757",
-      "outCountPlan": 0,
-      "outCountUnplan": 2,
-      "custOutPlan": 0,
-      "custOutUnplan": 969
     },
     {
       "zipCode": "84774",
       "outCountPlan": 0,
       "outCountUnplan": 1,
       "custOutPlan": 0,
-      "custOutUnplan": 1
+      "custOutUnplan": 17
     }
   ],
   "counties": [
     {
       "countyName": "Box Elder",
       "outCountPlan": 0,
-      "outCountUnplan": 10,
+      "outCountUnplan": 9,
       "custOutPlan": 0,
-      "custOutUnplan": 11
+      "custOutUnplan": 9
     },
     {
       "countyName": "Cache",
       "outCountPlan": 0,
-      "outCountUnplan": 16,
+      "outCountUnplan": 17,
       "custOutPlan": 0,
-      "custOutUnplan": 826
+      "custOutUnplan": 444
     },
     {
       "countyName": "Davis",
       "outCountPlan": 0,
-      "outCountUnplan": 2,
+      "outCountUnplan": 3,
       "custOutPlan": 0,
-      "custOutUnplan": 2
+      "custOutUnplan": 3
     },
     {
       "countyName": "Emery",
@@ -1768,9 +1752,9 @@
     {
       "countyName": "Iron",
       "outCountPlan": 0,
-      "outCountUnplan": 3,
+      "outCountUnplan": 1,
       "custOutPlan": 0,
-      "custOutUnplan": 529
+      "custOutUnplan": 1
     },
     {
       "countyName": "Juab",
@@ -1795,45 +1779,38 @@
     },
     {
       "countyName": "Salt Lake",
-      "outCountPlan": 0,
-      "outCountUnplan": 103,
-      "custOutPlan": 0,
-      "custOutUnplan": 4572
-    },
-    {
-      "countyName": "Sevier",
-      "outCountPlan": 0,
-      "outCountUnplan": 1,
-      "custOutPlan": 0,
-      "custOutUnplan": 1
+      "outCountPlan": 1,
+      "outCountUnplan": 108,
+      "custOutPlan": 1,
+      "custOutUnplan": 4853
     },
     {
       "countyName": "Summit",
       "outCountPlan": 0,
-      "outCountUnplan": 3,
+      "outCountUnplan": 4,
       "custOutPlan": 0,
-      "custOutUnplan": 996
+      "custOutUnplan": 997
     },
     {
       "countyName": "Tooele",
       "outCountPlan": 0,
-      "outCountUnplan": 4,
+      "outCountUnplan": 3,
       "custOutPlan": 0,
-      "custOutUnplan": 14
+      "custOutUnplan": 9
     },
     {
       "countyName": "Washington",
       "outCountPlan": 0,
-      "outCountUnplan": 3,
+      "outCountUnplan": 1,
       "custOutPlan": 0,
-      "custOutUnplan": 895
+      "custOutUnplan": 17
     },
     {
       "countyName": "Weber",
       "outCountPlan": 0,
       "outCountUnplan": 8,
       "custOutPlan": 0,
-      "custOutUnplan": 8
+      "custOutUnplan": 17
     }
   ]
 }

--- a/maplistWY.json
+++ b/maplistWY.json
@@ -1,7 +1,19 @@
 {
-  "count": 6,
-  "totalState": 85,
+  "count": 5,
+  "totalState": 29,
   "outages": [
+    {
+      "icon": "standard",
+      "longitude": -110.909,
+      "latitude": 41.212,
+      "etr": "Before 07:30 PM on 05/13",
+      "outCount": 1,
+      "custOut": 5,
+      "cause": "Investigating",
+      "crewStatus": "Crews Arrived",
+      "reported": "04:41 PM on 05/13",
+      "zip": "82930"
+    },
     {
       "icon": "standard",
       "longitude": -105.547,
@@ -20,8 +32,8 @@
       "latitude": 41.379,
       "etr": "Before 06:30 PM on 05/13",
       "outCount": 1,
-      "custOut": 12,
-      "cause": "Investigating",
+      "custOut": 17,
+      "cause": "Damaged Equipment",
       "crewStatus": "Crews Notified",
       "reported": "03:29 PM on 05/13",
       "zip": "82930"
@@ -40,27 +52,15 @@
     },
     {
       "icon": "standard",
-      "longitude": -109.648,
-      "latitude": 41.632,
-      "etr": "Before 05:00 PM on 05/13",
-      "outCount": 1,
-      "custOut": 65,
-      "cause": "Investigating",
-      "crewStatus": "Crews Arrived",
-      "reported": "11:56 AM on 05/13",
-      "zip": "82929, 82935, 82938"
-    },
-    {
-      "icon": "standard",
-      "longitude": -106.318,
-      "latitude": 42.856,
+      "longitude": -106.377,
+      "latitude": 42.858,
       "etr": "Assessing",
-      "outCount": 2,
-      "custOut": 2,
+      "outCount": 1,
+      "custOut": 1,
       "cause": "Investigating",
       "crewStatus": "Crews Notified",
-      "reported": "03:39 PM on 05/13",
-      "zip": "82601"
+      "reported": "04:58 PM on 05/13",
+      "zip": "82604"
     }
   ],
   "zips": [
@@ -72,39 +72,25 @@
       "custOutUnplan": 5
     },
     {
-      "zipCode": "82601",
+      "zipCode": "82604",
       "outCountPlan": 0,
-      "outCountUnplan": 2,
+      "outCountUnplan": 1,
       "custOutPlan": 0,
-      "custOutUnplan": 2
+      "custOutUnplan": 1
     },
     {
       "zipCode": "82929",
       "outCountPlan": 0,
-      "outCountUnplan": 2,
+      "outCountUnplan": 1,
       "custOutPlan": 0,
-      "custOutUnplan": 5
+      "custOutUnplan": 1
     },
     {
       "zipCode": "82930",
       "outCountPlan": 0,
-      "outCountUnplan": 1,
+      "outCountUnplan": 2,
       "custOutPlan": 0,
-      "custOutUnplan": 12
-    },
-    {
-      "zipCode": "82935",
-      "outCountPlan": 0,
-      "outCountUnplan": 1,
-      "custOutPlan": 0,
-      "custOutUnplan": 30
-    },
-    {
-      "zipCode": "82938",
-      "outCountPlan": 0,
-      "outCountUnplan": 1,
-      "custOutPlan": 0,
-      "custOutUnplan": 31
+      "custOutUnplan": 22
     }
   ],
   "counties": [
@@ -118,23 +104,23 @@
     {
       "countyName": "Natrona",
       "outCountPlan": 0,
-      "outCountUnplan": 2,
+      "outCountUnplan": 1,
       "custOutPlan": 0,
-      "custOutUnplan": 2
+      "custOutUnplan": 1
     },
     {
       "countyName": "Sweetwater",
       "outCountPlan": 0,
-      "outCountUnplan": 2,
+      "outCountUnplan": 1,
       "custOutPlan": 0,
-      "custOutUnplan": 66
+      "custOutUnplan": 1
     },
     {
       "countyName": "Uinta",
       "outCountPlan": 0,
-      "outCountUnplan": 1,
+      "outCountUnplan": 2,
       "custOutPlan": 0,
-      "custOutUnplan": 12
+      "custOutUnplan": 22
     }
   ]
 }


### PR DESCRIPTION
Data belongs to the source — we can't relicense it. Use disclaimer instead.